### PR TITLE
match library name with the exported cmake name

### DIFF
--- a/DBoW2.cmake.in
+++ b/DBoW2.cmake.in
@@ -1,4 +1,4 @@
-find_library(DBoW2_LIBRARY DBoW2
+find_library(DBoW2_LIBRARY dbow2
     PATHS "@CMAKE_INSTALL_PREFIX@/lib"
 )
 find_path(DBoW2_INCLUDE_DIR DBoW2/BowVector.h DBoW2/FeatureVector.h


### PR DESCRIPTION
cmake's `find_library` is case sensitive, therefore if we look for
`DBoW2` then we also need to export libDBoW2.so

I encountered this issue when trying to compile [OpenVSLAM](https://github.com/xdspacelab/openvslam) :)